### PR TITLE
Add CONTRIBUTING guide and clean README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to Herbarium Bot
+
+Thank you for considering a contribution!
+
+## Development Setup
+
+1. Fork the repository and clone your fork.
+2. Install the dependencies:
+   ```bash
+   uv sync
+   ```
+3. Install the pre-commit hooks:
+   ```bash
+   pre-commit install
+   ```
+4. Create a new branch for your work:
+   ```bash
+   git checkout -b feat/my-feature
+   ```
+
+## Commit Messages
+
+Use the `type(scope): summary` format, for example:
+`feat(bot): add new command`.
+
+Run the checks before committing:
+```bash
+pre-commit run --all-files
+```
+
+## Running Tests
+
+If you add or update functionality, update the tests and run:
+```bash
+uv run pytest
+```
+
+## Pull Requests
+
+Push your branch and open a pull request with a clear description of your changes.
+
+We appreciate your help in making Herbarium Bot better!

--- a/README.md
+++ b/README.md
@@ -183,11 +183,8 @@ Yes! Fork the repo, update the GitHub settings in your environment variables, an
 
 ## Contributing
 
-1. Fork this repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'feat: Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on setting up your
+development environment and opening pull requests.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add a CONTRIBUTING.md guide
- link to it from README and drop redundant info

## Testing
- `pytest -q`
- `pre-commit run --files README.md CONTRIBUTING.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e2b78180833383a59bf52941ac54